### PR TITLE
Mysql 767バイト問題

### DIFF
--- a/config/initializers/mysql.rb
+++ b/config/initializers/mysql.rb
@@ -1,0 +1,9 @@
+require 'active_record/connection_adapters/abstract_mysql_adapter'
+
+module ActiveRecord
+  module ConnectionAdapters
+    class AbstractMysqlAdapter
+      NATIVE_DATABASE_TYPES[:string] = { :name => "varchar", :limit => 191 }
+    end
+  end
+end


### PR DESCRIPTION
# What

Mysqlで767バイトを超えない様に設定ファイルを作成する

# Why

マイグレーションをするときにデータベースを削除する手間をなくすため